### PR TITLE
Fix asset:// URL loading for MediaPlayer

### DIFF
--- a/Sources/SkipAV/AVAudioPlayer.swift
+++ b/Sources/SkipAV/AVAudioPlayer.swift
@@ -52,7 +52,13 @@ open class AVAudioPlayer: AVObjectBase, KotlinConverting<MediaPlayer?> {
     private func initializeMediaPlayer(url: URL) throws {
         do {
             mediaPlayer = MediaPlayer().apply {
-                setDataSource(context, android.net.Uri.parse(url.absoluteString))
+                if url.absoluteString.starts(with: "asset:/") {
+                    var assetPath = url.absoluteString.removePrefix("asset:/")
+                    var afd = context.assets.openFd(assetPath)
+                    setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                } else {
+                    setDataSource(context, android.net.Uri.parse(url.absoluteString))
+                }
                 prepare()
             }
             setupMediaPlayerListeners()

--- a/Sources/SkipAV/AVAudioPlayer.swift
+++ b/Sources/SkipAV/AVAudioPlayer.swift
@@ -56,6 +56,7 @@ open class AVAudioPlayer: AVObjectBase, KotlinConverting<MediaPlayer?> {
                     var assetPath = url.absoluteString.removePrefix("asset:/")
                     var afd = context.assets.openFd(assetPath)
                     setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                    afd.close()
                 } else {
                     setDataSource(context, android.net.Uri.parse(url.absoluteString))
                 }

--- a/Sources/SkipAV/AVAudioPlayer.swift
+++ b/Sources/SkipAV/AVAudioPlayer.swift
@@ -53,8 +53,8 @@ open class AVAudioPlayer: AVObjectBase, KotlinConverting<MediaPlayer?> {
         do {
             mediaPlayer = MediaPlayer().apply {
                 if url.absoluteString.starts(with: "asset:/") {
-                    var assetPath = url.absoluteString.removePrefix("asset:/")
-                    var afd = context.assets.openFd(assetPath)
+                    let assetPath = url.absoluteString.removePrefix("asset:/")
+                    let afd = context.assets.openFd(assetPath)
                     setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
                     afd.close()
                 } else {


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Fixes an issue with MediaPlayer in the skip-av package when trying to play files from the source directory. The problem was due to an incorrect URL format, which this fix corrects by using the proper asset:/// scheme or file path expected by MediaPlayer.

Labels:
bug, android

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

