### PR TITLE
Fix playback rate to match iOS Float type

### DIFF
--- a/Sources/SkipAV/AVAudioPlayer.swift
+++ b/Sources/SkipAV/AVAudioPlayer.swift
@@ -17,6 +17,14 @@ public protocol AVAudioPlayerDelegate: AnyObject {
 }
 
 #if SKIP
+// Default implementations to make methods optional (matching iOS behavior)
+public extension AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {}
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {}
+}
+#endif
+
+#if SKIP
 // Cannot use typealias NSObject = java.lang.Object because it breaks the bridge generation
 //public typealias AVObjectBase = NSObject
 public protocol AVObjectBase { }


### PR DESCRIPTION
- Fix rate setter to preserve playback state when adjusting speed, since Android's setPlaybackParams automatically starts playback by default
- Change rate property from Double to Float with explicit cast to match iOS API

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

