### PR TITLE
Switch from androidx.media3.ui.PlayerView to androidx.media3.ui.compose.material3.Player

### DIFF
--- a/Sources/SkipAV/Skip/skip.yml
+++ b/Sources/SkipAV/Skip/skip.yml
@@ -16,6 +16,7 @@ settings:
                 - 'version("androidx-media", "1.9.2")'
                 - 'library("androidx-media-ui", "androidx.media3", "media3-ui").versionRef("androidx-media")'
                 - 'library("androidx-media-compose", "androidx.media3", "media3-ui-compose").versionRef("androidx-media")'
+                - 'library("androidx-media-compose-material3", "androidx.media3", "media3-ui-compose-material3").versionRef("androidx-media")'
                 - 'library("androidx-media-common", "androidx.media3", "media3-common").versionRef("androidx-media")'
                 - 'library("androidx-media-session", "androidx.media3", "media3-session").versionRef("androidx-media")'
                 - 'library("androidx-media-exoplayer", "androidx.media3", "media3-exoplayer").versionRef("androidx-media")'
@@ -30,6 +31,7 @@ build:
       contents:
         - 'api(libs.androidx.media.ui)'
         - 'api(libs.androidx.media.compose)'
+        - 'api(libs.androidx.media.compose.material3)'
         - 'api(libs.androidx.media.common)'
         - 'api(libs.androidx.media.session)'
         - 'api(libs.androidx.media.exoplayer)'

--- a/Sources/SkipAV/VideoPlayer.swift
+++ b/Sources/SkipAV/VideoPlayer.swift
@@ -6,15 +6,16 @@
 #elseif SKIP
 import SwiftUI
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.ui.PlayerView
 import androidx.media3.ui.AspectRatioFrameLayout
-import androidx.media3.ui.compose.PlayerSurface
-import androidx.media3.ui.compose.SURFACE_TYPE_SURFACE_VIEW
+import androidx.media3.ui.compose.material3.Player
 import androidx.media3.ui.compose.modifiers.resizeWithContentScale
 import androidx.media3.ui.compose.state.rememberPresentationState
-import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.delay
 
 public struct VideoPlayer: View {
     
@@ -36,30 +37,50 @@ public struct VideoPlayer: View {
     // SKIP @nobridge
     @Composable public override func ComposeContent(context: ComposeContext) {
         ComposeContainer(modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in
-            // we could use the newer Compose PlayerSurface, but unlike the older PlayerView, it doesn't include built-in playback controls, so we would need to create our own
-            /*
-            player.prepare(LocalContext.current)
-            let presentationState = rememberPresentationState(player.mediaPlayer!)
-            PlayerSurface(player: player.mediaPlayer!, surfaceType: SURFACE_TYPE_SURFACE_VIEW, modifier: modifier.resizeWithContentScale(ContentScale.Fit, presentationState.videoSizeDp))
-             */
+            // the new Compose Player does not auto-hide controls, so we need to manage this manually
 
-            AndroidView(factory: { ctx in
-                let playerView = PlayerView(ctx)
-                player.prepare(ctx)
-                playerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
-                playerView.controllerAutoShow = false // hide controls initially, like on iOS
-                playerView.player = player.mediaPlayer
-                // Enable fullscreen button and handle fullscreen transitions
-                if let isFullscreenBinding = self.isFullscreen {
-                    playerView.setControllerOnFullScreenModeChangedListener { isFullScreen in
-                        isFullscreenBinding.wrappedValue = isFullScreen
-                    }
-                }
-                return playerView
-            }, modifier: modifier, update: { playerView in
-            })
+            // this technique is based on https://github.com/androidx/media/blob/main/demos/compose/src/main/java/androidx/media3/demo/compose/layout/MainScreen.kt#L121
+
+            /* SKIP INSERT:
+
+            var showControls by remember { mutableStateOf(true) }
+            var anyPointerDown by remember { mutableStateOf(false) }
+            LaunchedEffect(showControls, anyPointerDown) {
+              if (showControls && !anyPointerDown) {
+                var CONTROLS_VISIBILITY_TIMEOUT_MS = Long(3000)
+                delay(CONTROLS_VISIBILITY_TIMEOUT_MS)
+                showControls = false
+              }
+            }
+            */
+
+            Player(player: player.mediaPlayer!,
+                   showControls: showControls,
+                   // not yet working
+                   // we need some modifiers like playerGestures in https://github.com/v-novaltd/androidx-media/blob/ae06ff489eb737bb6141f075e7d602873aeb84b8/demos/compose/src/main/java/androidx/media3/demo/compose/layout/modifiers.kt#L52
+                   modifier: modifier
+                    //.playerGestures(
+                    //onPointerDownChange: { anyPointerDown = it },
+                    //onToggleControls: { showControls = !showControls },
+                    //playbackSpeedState: playbackSpeedState,
+                    //seekBackButtonState: rememberSeekBackButtonState(player),
+                    //seekForwardButtonState: rememberSeekForwardButtonState(player),
+                    //seekBackActionArea: { offset -> offset.x < size.width / 2 },
+                    //seekForwardActionArea: { offset -> offset.x >= size.width / 2 },
+                    //onSeek: {
+                    //  showControls = false
+                    //  seekOverlayState.show(it)
+                    //},
+                    //fastForwardActionArea: { offset -> offset.x >= size.width / 2 },
+                    //onFastForward: {
+                    //  showControls = false
+                    //  showFastForward = it
+                    //},
+                    //)
+                   )
         }
     }
 }
+
 #endif
 #endif


### PR DESCRIPTION
Media3 1.10 [announced](https://android-developers.googleblog.com/2026/03/media3-110-is-out.html) a new compose-friendly [`androidx.media3.ui.compose.material3.Player`](https://developer.android.com/reference/kotlin/androidx/media3/ui/compose/material3/Player.composable) Composable, which would be a better fit than our current `AndroidView` wrapper around [`androidx.media3.ui.PlayerView`](https://developer.android.com/reference/androidx/media3/ui/PlayerView).

It supports built-in controls, but unfortunately doesn't have any affordances for auto-hiding the controls, so we would need to implement something like that, perhaps like the example at: https://github.com/androidx/media/blob/main/demos/compose/src/main/java/androidx/media3/demo/compose/layout/MainScreen.kt#L121. Or else we can wait for them to add an auto-hide parameter to the player.