### PR TITLE
Rebind PlayerView during AndroidView updates

### DIFF
--- a/Sources/SkipAV/VideoPlayer.swift
+++ b/Sources/SkipAV/VideoPlayer.swift
@@ -57,6 +57,7 @@ public struct VideoPlayer: View {
                 }
                 return playerView
             }, modifier: modifier, update: { playerView in
+                playerView.player = player.mediaPlayer
             })
         }
     }


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code, tested manually from a native app

-----


- Rebind the Android `PlayerView` to the current `AVPlayer.mediaPlayer` during `AndroidView` updates.
- This keeps the existing `PlayerView` in sync when SwiftUI/Skip re-renders with an updated player instead of only wiring the player during initial view creation.

Here is a[ minimal repro package](https://github.com/tifroz/skip-av-playerview-repro)