### PR TITLE
Seek to the live edge for CMTime.positiveInfinity

### DIFF
--- a/Sources/SkipAV/AVPlayer.swift
+++ b/Sources/SkipAV/AVPlayer.swift
@@ -232,11 +232,24 @@ public class AVPlayer {
     }
 
     public func seek(to time: CMTime) {
-        mediaPlayer.seekTo(Int64(time.seconds * 1000.0))
+        if time.isPositiveInfinity {
+            // AVPlayer treats positiveInfinity as "seek to the end / live edge". Media3 has no infinity
+            // sentinel, so clamp to a known duration (VOD) else jump to the default position (live edge). (#19)
+            let durationMs = mediaPlayer.duration
+            if durationMs > Int64(0) {
+                mediaPlayer.seekTo(durationMs)
+            } else {
+                mediaPlayer.seekToDefaultPosition()
+            }
+        } else if time.isNumeric {
+            mediaPlayer.seekTo(Int64(time.seconds * 1000.0))
+        }
+        // Other non-numeric times (indefinite/invalid/negativeInfinity) have no numeric position;
+        // ignore them rather than seek to a garbage offset, matching AVPlayer's no-op for such seeks.
     }
 
     public func seek(to time: CMTime, completionHandler: @escaping (Bool) -> Void) {
-        mediaPlayer.seekTo(Int64(time.seconds * 1000.0))
+        seek(to: time)
         // Media3's seekTo is synchronous in queueing the request; signal completion immediately.
         completionHandler(true)
     }

--- a/Tests/SkipAVTests/SkipAVTests.swift
+++ b/Tests/SkipAVTests/SkipAVTests.swift
@@ -178,5 +178,12 @@ final class SkipAVTests: XCTestCase {
         player.seek(to: CMTime.zero, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
         player.seek(to: CMTime.zero, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero) { _ in
         }
+
+        // Exercise the live-edge (positiveInfinity) and non-numeric seek paths; they must not crash. (#19)
+        player.seek(to: CMTime.positiveInfinity)
+        player.seek(to: CMTime.positiveInfinity) { _ in
+        }
+        player.seek(to: CMTime.indefinite)
+        player.seek(to: CMTime.invalid)
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #19. On Apple platforms `player.seek(to: .positiveInfinity)` is the idiomatic way to jump to the live edge of an HLS stream. `CMTime.positiveInfinity` already exists in SkipAV, but the Android `AVPlayer.seek(to:)` fed it straight into `Int64(time.seconds * 1000.0)` — there `seconds` is `Double.infinity`, which saturates to `Long.MAX_VALUE`, so `Player.seekTo` receives a meaningless offset instead of the live edge. `.indefinite`/`.invalid` (NaN seconds) were likewise passed through unchecked.

## Fix

In the transpiled `seek(to:)`:
- `positiveInfinity` → clamp to a known duration (VOD) via `seekTo(duration)`, else `Player.seekToDefaultPosition()` — the live edge for live streams (per the Media3 docs / your note on the issue).
- numeric times → unchanged.
- other non-numeric times (`indefinite`/`invalid`/`negativeInfinity`) → ignored rather than seeking to a garbage offset, matching AVPlayer's no-op for such seeks.

`seek(to:completionHandler:)` now delegates to `seek(to:)` so every seek path shares the same handling.

## Bridging

No bridging changes — the fix lives entirely inside the existing `#elseif SKIP` branch; the iOS path (`@_exported import AVKit`) is untouched.

## Testing

`swift test` is green on both platforms (native XCTest + transpiled Robolectric). `testAVPlayerAdditions` now also exercises the `positiveInfinity`/`indefinite`/`invalid` seek paths. Note: the live-edge vs. saturated-offset difference only manifests against a real HLS stream (Robolectric has no media pipeline), so that addition is a smoke check of the new code paths rather than a behavioral assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
