### PR TITLE
Fix AVAudioRecorder Android parity with AVFoundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ This framework also supports the 'AVFoundation.AVAudioRecorder' and
 AVFoundation.AVAudioPlayer' APIs via Android's MediaRecorder and MediaPlayer. 
 These APIs can be used for audio recording and playback.
 
+Some Android-specific behavior is worth noting when recording:
+
+  - Metering follows the AVFoundation sequence: set `isMeteringEnabled`, call
+    `updateMeters()`, then read `peakPower(forChannel:)` or `averagePower(forChannel:)`.
+    Values are in decibels relative to full scale, from `-160.0` for silence to `0.0`
+    at full scale. `MediaRecorder` only reports a peak amplitude, so `averagePower`
+    returns the same value as `peakPower`.
+  - `AVFormatIDKey` is ignored. `MediaRecorder` has no linear PCM output format, so
+    recordings are always AAC in an MPEG-4 container. `AVNumberOfChannelsKey`,
+    `AVSampleRateKey`, and `AVEncoderBitRateKey` are applied.
+  - Recording to the microphone requires the `android.permission.RECORD_AUDIO`
+    permission to have been granted before `AVAudioRecorder` is created.
+
 ```swift
 import SwiftUI
 import AVFoundation
@@ -243,7 +256,7 @@ Support levels:
               <ul>
                   <li><code>init(url: URL, settings: [String: Any]) throws</code></li>
                   <li><code>func prepareToRecord() -> Bool</code></li>
-                  <li><code>func record()</code></li>
+                  <li><code>@discardableResult func record() -> Bool</code></li>
                   <li><code>func pause()</code></li>
                   <li><code>func stop()</code></li>
                   <li><code>func deleteRecording() -> Bool</code></li>
@@ -251,8 +264,10 @@ Support levels:
                   <li><code>var url: URL</code></li>
                   <li><code>var settings: [String: Any]</code></li>
                   <li><code>var currentTime: TimeInterval</code></li>
+                  <li><code>var isMeteringEnabled: Bool</code></li>
+                  <li><code>func updateMeters()</code></li>
                   <li><code>func peakPower(forChannel channelNumber: Int) -> Float</code></li>
-                  <li><code>func averagePower(forChannel channelNumber: Int) -> Double</code></li>
+                  <li><code>func averagePower(forChannel channelNumber: Int) -> Float</code></li>
               </ul>
           </details> 
       </td>

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -23,7 +23,10 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
     private let context = ProcessInfo.processInfo.androidContext
     private var filePath: String?
 
+    /// The start of the segment that is currently being recorded, or `nil` when not recording.
     private var recordingStartTime: Date?
+    /// The duration of the segments recorded before the most recent `pause()`.
+    private var accumulatedTime: TimeInterval = 0.0
     public weak var delegate: AVAudioRecorderDelegate?
 
     private var _isRecording = false
@@ -93,6 +96,10 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
 
     public func pause() {
         recorder?.pause()
+        if let startTime = recordingStartTime {
+            accumulatedTime += Date().timeIntervalSince(startTime)
+        }
+        recordingStartTime = nil
         _isRecording = false
     }
 
@@ -103,6 +110,7 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
             recorder = nil
             _isRecording = false
             recordingStartTime = nil
+            accumulatedTime = 0.0
 
             delegate?.audioRecorderDidFinishRecording(self, successfully: true)
         } catch {
@@ -138,11 +146,10 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
     }
 
     public var currentTime: TimeInterval {
-        if let startTime = recordingStartTime {
-            return startTime.timeIntervalSinceNow
-        } else {
-            return TimeInterval(0)
+        guard let startTime = recordingStartTime else {
+            return accumulatedTime
         }
+        return accumulatedTime + Date().timeIntervalSince(startTime)
     }
 
     public func peakPower(forChannel channelNumber: Int) -> Float {

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -63,6 +63,27 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
         return recorder
     }
 
+    /// Reads a numeric entry from `settings`.
+    ///
+    /// AVFoundation's audio settings are documented as `NSNumber` values, so a caller may
+    /// legitimately pass `44100`, `44100.0`, or a `Float`. Matching only against `Int` silently
+    /// dropped the other two and fell back to the default.
+    private func intSetting(_ key: String) -> Int? {
+        guard let value = _settings[key] else {
+            return nil
+        }
+        if let intValue = value as? Int {
+            return intValue
+        }
+        if let doubleValue = value as? Double {
+            return Int(doubleValue)
+        }
+        if let floatValue = value as? Float {
+            return Int(floatValue)
+        }
+        return nil
+    }
+
     public func prepareToRecord() -> Bool {
         do {
             let file = File(_url.path)
@@ -76,9 +97,9 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
                 setAudioSource(MediaRecorder.AudioSource.MIC)
                 setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
                 setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-                setAudioChannels(2)
-                setAudioSamplingRate(settings["AVSampleRateKey"] as? Int ?? 44100)
-                setAudioEncodingBitRate(settings["AVEncoderBitRateKey"] as? Int ?? 128000)
+                setAudioChannels(intSetting(AVNumberOfChannelsKey) ?? 2)
+                setAudioSamplingRate(intSetting(AVSampleRateKey) ?? 44100)
+                setAudioEncodingBitRate(intSetting(AVEncoderBitRateKey) ?? 128000)
                 setOutputFile(filePath)
                 prepare()
             }

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -156,9 +156,9 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
         return Float(recorder?.maxAmplitude ?? 0) / Float(32767.0)
     }
 
-    public func averagePower(forChannel channelNumber: Int) -> Double {
+    public func averagePower(forChannel channelNumber: Int) -> Float {
         // Android doesn't provide average power, so we'll return peak power
-        return Double(recorder?.maxAmplitude ?? 0) / 32767.0
+        return Float(recorder?.maxAmplitude ?? 0) / Float(32767.0)
     }
 }
 #endif

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -30,6 +30,8 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
     public weak var delegate: AVAudioRecorderDelegate?
 
     private var _isRecording = false
+    /// Set by `pause()` so that the next `record()` resumes instead of restarting.
+    private var isPaused = false
     private var _url: URL
     private var _settings: [String: Any]
 
@@ -86,23 +88,36 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
         }
     }
 
-    public func record() {
+    @discardableResult public func record() -> Bool {
+        if recorder == nil && !prepareToRecord() {
+            return false
+        }
         do {
-            prepareToRecord()
-            recorder?.start()
+            if isPaused {
+                recorder?.resume()
+                isPaused = false
+            } else {
+                recorder?.start()
+            }
             _isRecording = true
             recordingStartTime = Date()
+            return true
         } catch {
             delegate?.audioRecorderEncodeErrorDidOccur(self, error: error)
+            return false
         }
     }
 
     public func pause() {
+        guard _isRecording else {
+            return
+        }
         recorder?.pause()
         if let startTime = recordingStartTime {
             accumulatedTime += Date().timeIntervalSince(startTime)
         }
         recordingStartTime = nil
+        isPaused = true
         _isRecording = false
     }
 
@@ -112,6 +127,7 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
             recorder?.release()
             recorder = nil
             _isRecording = false
+            isPaused = false
             recordingStartTime = nil
             accumulatedTime = 0.0
             meterAmplitude = 0

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -153,12 +153,27 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
     }
 
     public func peakPower(forChannel channelNumber: Int) -> Float {
-        return Float(recorder?.maxAmplitude ?? 0) / Float(32767.0)
+        return AVAudioRecorder.amplitudeToDecibels(recorder?.maxAmplitude ?? 0)
     }
 
     public func averagePower(forChannel channelNumber: Int) -> Float {
         // Android doesn't provide average power, so we'll return peak power
-        return Float(recorder?.maxAmplitude ?? 0) / Float(32767.0)
+        return AVAudioRecorder.amplitudeToDecibels(recorder?.maxAmplitude ?? 0)
+    }
+
+    /// Converts an `android.media.MediaRecorder` amplitude (0...32767) to the
+    /// decibel scale that AVFoundation's power accessors report, where full
+    /// scale is 0 dB and silence is -160 dB.
+    ///
+    /// Exposed for testing; like `init(platformValue:url:)` this has no iOS counterpart.
+    // SKIP @nobridge
+    public static func amplitudeToDecibels(_ amplitude: Int) -> Float {
+        guard amplitude > 0 else {
+            return Float(-160.0)
+        }
+        // SkipLib provides log10(Double) and log10f(Float), but no log10(Float),
+        // so the conversion is computed in Double and narrowed afterwards.
+        return Float(20.0 * log10(Double(amplitude) / 32767.0))
     }
 }
 #endif

--- a/Sources/SkipAV/AVAudioRecorder.swift
+++ b/Sources/SkipAV/AVAudioRecorder.swift
@@ -33,8 +33,11 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
     private var _url: URL
     private var _settings: [String: Any]
 
-    @available(*, unavailable)
-    public var meteringEnabled = false
+    /// Turns level metering on or off. Metering is disabled by default, matching AVFoundation.
+    public var isMeteringEnabled = false
+
+    /// The amplitude sampled by the most recent `updateMeters()` call.
+    private var meterAmplitude: Int = 0
 
     public init(url: URL, settings: [String: Any]) throws {
         self._url = url
@@ -111,6 +114,7 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
             _isRecording = false
             recordingStartTime = nil
             accumulatedTime = 0.0
+            meterAmplitude = 0
 
             delegate?.audioRecorderDidFinishRecording(self, successfully: true)
         } catch {
@@ -152,13 +156,25 @@ public class AVAudioRecorder: KotlinConverting<MediaRecorder?> {
         return accumulatedTime + Date().timeIntervalSince(startTime)
     }
 
+    /// Refreshes the values returned by `peakPower(forChannel:)` and `averagePower(forChannel:)`.
+    ///
+    /// `MediaRecorder.getMaxAmplitude()` reports the maximum amplitude sampled since it was last
+    /// called and resets on every read, so the value is sampled once here and cached. Reading it
+    /// directly from each accessor would make whichever accessor ran second observe silence.
+    public func updateMeters() {
+        guard isMeteringEnabled else {
+            return
+        }
+        meterAmplitude = recorder?.maxAmplitude ?? 0
+    }
+
     public func peakPower(forChannel channelNumber: Int) -> Float {
-        return AVAudioRecorder.amplitudeToDecibels(recorder?.maxAmplitude ?? 0)
+        return AVAudioRecorder.amplitudeToDecibels(meterAmplitude)
     }
 
     public func averagePower(forChannel channelNumber: Int) -> Float {
         // Android doesn't provide average power, so we'll return peak power
-        return AVAudioRecorder.amplitudeToDecibels(recorder?.maxAmplitude ?? 0)
+        return AVAudioRecorder.amplitudeToDecibels(meterAmplitude)
     }
 
     /// Converts an `android.media.MediaRecorder` amplitude (0...32767) to the

--- a/Tests/SkipAVTests/SkipAVTests.swift
+++ b/Tests/SkipAVTests/SkipAVTests.swift
@@ -136,6 +136,30 @@ final class SkipAVTests: XCTestCase {
         #endif
     }
 
+    #if SKIP
+    // SkipAV's AVAudioRecorder is the Android implementation; on iOS the real
+    // AVFoundation type is re-exported, so this conversion only exists here.
+    public func testAudioRecorderAmplitudeToDecibels() throws {
+        // Silence and any invalid amplitude clamp to AVFoundation's floor.
+        XCTAssertEqual(Float(-160.0), AVAudioRecorder.amplitudeToDecibels(0))
+        XCTAssertEqual(Float(-160.0), AVAudioRecorder.amplitudeToDecibels(-1))
+
+        // Full scale is 0 dB. AVFoundation never reports a positive power.
+        let fullScale = AVAudioRecorder.amplitudeToDecibels(32767)
+        XCTAssertTrue(fullScale <= Float(0.0), "full scale should not exceed 0 dB, was \(fullScale)")
+        XCTAssertTrue(fullScale > Float(-0.01), "full scale should be 0 dB, was \(fullScale)")
+
+        // A tenth of full scale is -20 dB, and half is about -6 dB.
+        let tenth = AVAudioRecorder.amplitudeToDecibels(3277)
+        XCTAssertTrue(tenth > Float(-20.1) && tenth < Float(-19.9), "expected about -20 dB, was \(tenth)")
+        let half = AVAudioRecorder.amplitudeToDecibels(16384)
+        XCTAssertTrue(half > Float(-6.1) && half < Float(-6.0), "expected about -6 dB, was \(half)")
+
+        // The scale is monotonic, so a louder sample never reports a lower power.
+        XCTAssertTrue(AVAudioRecorder.amplitudeToDecibels(100) < AVAudioRecorder.amplitudeToDecibels(1000))
+    }
+    #endif
+
     public func testAVPlayerAdditions() throws {
         let player = AVPlayer(url: videoURL)
 


### PR DESCRIPTION
Fixes #28.

Brings the Android `AVAudioRecorder` in `Sources/SkipAV/AVAudioRecorder.swift` in line with the AVFoundation API it stands in for. Only the `#elseif SKIP` branch is touched — iOS re-exports AVKit and is unaffected.

Each fix is a separate commit, so anything you'd rather not take can be dropped without unpicking the rest.

| Commit | Fix |
| --- | --- |
| `cff6cf5` | `currentTime` returned a negative elapsed time, and restarted from zero after `pause()` |
| `906417b` | `averagePower(forChannel:)` returned `Double`; the header declares `float` |
| `50517a3` | Power was a 0...1 linear ratio; AVFoundation reports decibels (`-160.0` ... `0.0`) |
| `3c4cdbd` | `isMeteringEnabled` and `updateMeters()` were missing, so metering was unusable |
| `d195af0` | `record()` restarted rather than resumed after `pause()`, and returned `Void` |
| `2e1ae9b` | `AVNumberOfChannelsKey` was ignored; numeric settings only matched `Int` |
| `b91f9ab` | Test for the metering conversion, README corrections |

## Behavior changes

Two of these change what existing Android code observes. Flagging them for a `breaking-change` label if you agree they warrant one.

**Metering now returns decibels.** Code written against the old 0...1 range needs converting:

```swift
// before: level was 0.0...1.0
let level = recorder.averagePower(forChannel: 0)

// after: powers are in dB, and metering must be enabled and refreshed
recorder.isMeteringEnabled = true
recorder.updateMeters()
let level = pow(10.0, recorder.averagePower(forChannel: 0) / 20.0)   // back to 0.0...1.0
```

**`record()` after `pause()` now resumes.** Code that relied on the old behavior to restart a take should call `stop()` and then `record()`.

`record()` gaining a `Bool` return is source-compatible via `@discardableResult`.

## Notes on the implementation

- `updateMeters()` samples the amplitude once and caches it, rather than each accessor reading `MediaRecorder.getMaxAmplitude()` directly. That call resets on every read, so reading it from both accessors made whichever ran second observe silence. The AVFoundation shape happens to be exactly the right fit for this.
- The decibel conversion is computed in `Double` and narrowed to `Float` at the end: SkipLib exposes `log10(Double)` and `log10f(Float)` but no `log10(Float)` overload.
- `amplitudeToDecibels(_:)` is `public static` and Android-only so the test can reach it from the test module — following the existing convention in this file for `init(platformValue:url:)` and `kotlin(nocopy:)`. Happy to make it internal and drop the test if you'd rather not add API surface.
- `AVFormatIDKey` is still ignored, since `MediaRecorder` has no linear PCM output format. Rather than partially mapping it, the README now states that recordings are always AAC/MPEG-4.

## Verification

- `swift test` passes locally: 5/5 Swift-side tests, including the new one. The `XCSkipTests` gradle harness did not run — no Gradle on this machine — so the transpiled Kotlin tests are down to CI.
- I did inspect the generated Kotlin under `.build/plugins/outputs/.../skip/av/AVAudioRecorder.kt` and confirmed the conversions resolve against `skip.lib` (`Int(Number)`, `Float(Number)`, `log10(Double)`).
- **The Android runtime behavior is not verified by me.** In particular the `pause()` / `resume()` change and the metering values need a device or emulator to confirm. I'd appreciate a check there, or point me at how you'd like it exercised and I'll do it.

Marked as draft for that reason. Happy to reshape the scope — the first two commits are the uncontroversial ones if you'd prefer to start there.
